### PR TITLE
fix: Add determine console code page encoding

### DIFF
--- a/click_pwsh/__main__.py
+++ b/click_pwsh/__main__.py
@@ -12,6 +12,17 @@ import click
 def main():
     pass
 
+def get_current_encoding() -> str:
+    """
+    Determines the current console code page encoding by executing a PowerShell command.
+    Retrieve the active code page from the `chcp` command output and extract code from byte string.
+    Returns:
+        str: The current console code page encoding as a string.
+    """
+    encoding = sp.run('pwsh -c "(chcp | Out-String).Split(\' \')[-1].Trim()"', shell=False, capture_output=True)
+    encoding = ''.join(chr(byte) for byte in encoding.stdout if byte not in (b'\r', b'\n'))
+    
+    return encoding
 
 @main.command()
 @click.argument("command")
@@ -19,7 +30,7 @@ def install(command):
     """Land the shell completion to PowerShell 7."""
     profile = (
         sp.run('pwsh -c "echo $PROFILE"', shell=True, capture_output=True)
-        .stdout.decode()
+        .stdout.decode(get_current_encoding())
         .strip()
     )
     profile = Path(profile)
@@ -50,7 +61,7 @@ def update(command):
     """Update shell completion scripts to PowerShell 7."""
     profile = (
         sp.run('pwsh -c "echo $PROFILE"', shell=True, capture_output=True)
-        .stdout.decode()
+        .stdout.decode(get_current_encoding())
         .strip()
     )
     profile = Path(profile)


### PR DESCRIPTION
Hello!

In my case, the first installation failed:
```bash
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x84 in position 24: invalid start byte
```
`$PROFILE` contains characters that are linked to the encoding of the system. As it turned out, the console uses a different encoding. I added explicit page code from `chcp` to specify the desired encoding for the `.encode()` function.

I hope you find these changes useful. Thank you so much for this package. It helped a lot for my app.