### PR TITLE
Fix deprecated import for split_arg_string

### DIFF
--- a/click_pwsh/shell_completion.py
+++ b/click_pwsh/shell_completion.py
@@ -5,8 +5,7 @@
 import os
 import typing as t
 
-from click.parser import split_arg_string
-from click.shell_completion import CompletionItem, ShellComplete
+from click.shell_completion import CompletionItem, ShellComplete, split_arg_string
 
 _SOURCE_PWSH = """\
 Register-ArgumentCompleter -Native -CommandName %(prog_name)s -ScriptBlock {


### PR DESCRIPTION
In newer versions of `click`, a deprecation warning suggests to import split_arg_string from module click.shell_completion instead.

Fortunately, it is available in shell_completion as a re-export even in click 8.0.0 which is the target dependency of click-pwsh.

See https://github.com/pallets/click/commit/3630addf538ff4d1d5bc75438c8d84378105d03d